### PR TITLE
fix: Change Welcome Message stage filter to send null

### DIFF
--- a/src/pages/AnalyticsNew.tsx
+++ b/src/pages/AnalyticsNew.tsx
@@ -130,7 +130,7 @@ const Analytics = () => {
       // Handle Welcome Message (NULL stage)
       if (selectedStage) {
         if (selectedStage === 'Welcome Message') {
-          params.append('stage', 'WELCOME_MESSAGE_NULL');
+          params.append('stage', null);
         } else {
           params.append('stage', selectedStage);
         }


### PR DESCRIPTION
## Changes
- Changed `params.append('stage', 'WELCOME_MESSAGE_NULL')` to `params.append('stage', null)`

## Important Note
⚠️ **URLSearchParams behavior**: When you call `params.append('stage', null)`, JavaScript's URLSearchParams will convert `null` to the string `"null"`. The resulting query string will be: `?stage=null`

## Backend Requirement
The backend API should handle the query parameter `?stage=null` (as a string) to filter for records where the stage column is NULL or empty.

## Testing
✅ Build passed
✅ Frontend built successfully
✅ Backend built with CGO_ENABLED=0

## Droid-Assisted
This PR was created with assistance from Droid.