### PR TITLE
Remove system status component from sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ import { DeviceProvider, useDevice } from './contexts/DeviceContext';
 import ProtectedRoute from './components/ProtectedRoute';
 import TopBar from './components/TopBar';
 import DeviceRequiredWrapper from './components/DeviceRequiredWrapper';
-import SimpleSystemStatus from './components/SimpleSystemStatus';
+
 
 const queryClient = new QueryClient();
 
@@ -121,12 +121,7 @@ function AppContent() {
           })}
         </nav>
         
-        {/* System Status - ADD TO ACTUAL SIDEBAR */}
-        <div className="mt-8 px-4">
-          <div className="border-t border-slate-200/50 dark:border-slate-700/50 pt-4">
-            <SimpleSystemStatus />
-          </div>
-        </div>
+
       </div>
 
       {/* Mobile sidebar overlay */}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -28,7 +28,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import SimpleSystemStatus from '@/components/SimpleSystemStatus';
+
 
 interface SidebarProps {
   collapsed: boolean;
@@ -230,12 +230,7 @@ const Sidebar = ({ collapsed, onToggle }: SidebarProps) => {
               </div>
             </div>
 
-            <Separator className="my-4 mx-3" />
-            
-            {/* Status - CLEAN SIMPLE VERSION */}
-            <div className="px-3">
-              <SimpleSystemStatus />
-            </div>
+
           </>
         )}
       </div>


### PR DESCRIPTION
## 📋 Summary

This pull request removes the **SimpleSystemStatus** component (showing 'All services running') from the sidebar completely as requested by the user.

## 🔧 Changes Made

- ✅ **Removed SimpleSystemStatus import** from  and 
- ✅ **Removed system status display section** from sidebar in both components  
- ✅ **Cleaned up unused imports** and empty sections
- ✅ **No breaking changes** - all other functionality preserved

## 🧪 Testing

- ✅ **Frontend Build**: Compiles successfully with 
> vite_react_shadcn_ts@0.0.0 build
> vite build

[36mvite v5.4.19 [32mbuilding for production...[36m[39m
transforming...
[32m✓[39m 2825 modules transformed.
rendering chunks...
computing gzip size...
[2mdist/[22m[32mindex.html                 [39m[1m[2m  1.36 kB[22m[1m[22m[2m │ gzip:   0.79 kB[22m
[2mdist/[22m[2massets/[22m[35mindex-Of7IzBux.css  [39m[1m[2m103.04 kB[22m[1m[22m[2m │ gzip:  16.89 kB[22m
[2mdist/[22m[2massets/[22m[36mindex-WUnyfsBE.js   [39m[1m[33m925.01 kB[39m[22m[2m │ gzip: 271.49 kB[22m
[32m✓ built in 8.25s[39m
- ✅ **Linting**: No new ESLint errors introduced
- ✅ **Functionality**: Sidebar navigation remains fully functional
- ✅ **UI**: Clean sidebar without status component

## 📂 Files Modified

-  - Removed SimpleSystemStatus import and usage
-  - Removed SimpleSystemStatus import and usage

## 🎯 Result

The sidebar now appears clean without the 'All services running' system status element, exactly as requested. All navigation functionality remains intact.

---

**Droid-assisted** PR with complete testing and validation.