### PR TITLE
Fix: Auth middleware to use string user_id for CHAR(36) compatibility

### DIFF
--- a/internal/handlers/ai_whatsapp_handlers.go
+++ b/internal/handlers/ai_whatsapp_handlers.go
@@ -1321,7 +1321,7 @@ func (h *AIWhatsappHandlers) GetAnalytics(c *fiber.Ctx) error {
 	}
 
 	// Get user ID from authentication context
-	userID, ok := c.Locals("userID").(int)
+	userID, ok := c.Locals("user_id").(string)
 	if !ok {
 		logrus.Error("User ID not found in context")
 		return c.Status(fiber.StatusUnauthorized).JSON(AnalyticsResponse{
@@ -1331,7 +1331,7 @@ func (h *AIWhatsappHandlers) GetAnalytics(c *fiber.Ctx) error {
 	}
 
 	// Get analytics data from repository with user-specific filtering
-	analyticsData, err := h.AIRepo.GetAnalyticsData(startDate, endDate, req.DeviceID, userID)
+	analyticsData, err := h.AIRepo.GetAnalyticsData(startDate, endDate, req.DeviceID, convertUUIDToInt(userID))
 	if err != nil {
 		logrus.WithError(err).Error("Failed to get analytics data")
 		return c.Status(fiber.StatusInternalServerError).JSON(AnalyticsResponse{
@@ -1389,7 +1389,7 @@ func (h *AIWhatsappHandlers) GetAllAIWhatsappData(c *fiber.Ctx) error {
 	offset := (page - 1) * limit
 
 	// Get user ID from authentication context
-	userID, ok := c.Locals("userID").(int)
+	userID, ok := c.Locals("user_id").(string)
 	if !ok {
 		logrus.Error("User ID not found in context")
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
@@ -1399,7 +1399,7 @@ func (h *AIWhatsappHandlers) GetAllAIWhatsappData(c *fiber.Ctx) error {
 	}
 
 	// Get data from repository with user-specific filtering
-	data, total, err := h.AIRepo.GetAllAIWhatsappData(limit, offset, deviceFilter, stageFilter, search, userID)
+	data, total, err := h.AIRepo.GetAllAIWhatsappData(limit, offset, deviceFilter, stageFilter, search, convertUUIDToInt(userID))
 	if err != nil {
 		logrus.WithError(err).Error("Failed to get AI WhatsApp data")
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{

--- a/internal/handlers/auth_handlers.go
+++ b/internal/handlers/auth_handlers.go
@@ -368,8 +368,7 @@ func (ah *AuthHandlers) Login(c *fiber.Ctx) error {
 	logrus.WithField("user_id", user.ID).Info("User logged in successfully")
 
 	// Check if user has devices for redirect logic
-	userIDInt := convertUUIDToInt(user.ID)
-	deviceCount, deviceIDs, err := ah.CheckUserDevices(userIDInt)
+	deviceCount, deviceIDs, err := ah.CheckUserDevices(user.ID)
 	if err != nil {
 		logrus.WithError(err).WithField("user_id", user.ID).Error("Failed to check user devices after login")
 		// Don't fail login, just log the error
@@ -545,13 +544,8 @@ func (ah *AuthHandlers) AuthMiddleware() fiber.Handler {
 			})
 		}
 
-		// Convert UUID string to integer for device handlers compatibility
-		// This creates a consistent integer mapping from the UUID
-		userIDInt := convertUUIDToInt(userID)
-
-		// Set user ID in context with the key expected by device handlers
-		c.Locals("userID", userIDInt)
-		c.Locals("user_id", userID) // Keep the string version for backward compatibility
+		// Set user ID in context as string UUID (CHAR(36) format)
+		c.Locals("user_id", userID) // Primary key for all handlers
 		return c.Next()
 	}
 }
@@ -560,8 +554,8 @@ func (ah *AuthHandlers) AuthMiddleware() fiber.Handler {
 func (ah *AuthHandlers) DeviceRequiredMiddleware() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		// Get user ID from context (should be set by AuthMiddleware)
-		userID, ok := c.Locals("userID").(int)
-		if !ok {
+		userIDStr, ok := c.Locals("user_id").(string)
+		if !ok || userIDStr == "" {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
 				"success": false,
 				"error":   "Authentication required",
@@ -573,9 +567,9 @@ func (ah *AuthHandlers) DeviceRequiredMiddleware() fiber.Handler {
 		err := ah.db.QueryRow(`
 			SELECT COUNT(*) FROM device_setting_nodepath 
 			WHERE user_id = ?
-		`, userID).Scan(&count)
+		`, userIDStr).Scan(&count)
 		if err != nil {
-			logrus.WithError(err).WithField("userID", userID).Error("Failed to check user device count")
+			logrus.WithError(err).WithField("userID", userIDStr).Error("Failed to check user device count")
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 				"success": false,
 				"error":   "Internal server error",
@@ -597,7 +591,7 @@ func (ah *AuthHandlers) DeviceRequiredMiddleware() fiber.Handler {
 }
 
 // CheckUserDevices returns device count and device IDs for a user
-func (ah *AuthHandlers) CheckUserDevices(userID int) (int, []string, error) {
+func (ah *AuthHandlers) CheckUserDevices(userID string) (int, []string, error) {
 	// Check if database connection is available
 	if ah.db == nil {
 		return 0, nil, fmt.Errorf("database connection is not available")
@@ -635,8 +629,8 @@ func (ah *AuthHandlers) CheckUserDevices(userID int) (int, []string, error) {
 // GetDeviceStatus returns the device status for the authenticated user
 func (ah *AuthHandlers) GetDeviceStatus(c *fiber.Ctx) error {
 	// Get user ID from context
-	userID, ok := c.Locals("userID").(int)
-	if !ok {
+	userIDStr, ok := c.Locals("user_id").(string)
+	if !ok || userIDStr == "" {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
 			"success": false,
 			"error":   "Authentication required",
@@ -644,9 +638,9 @@ func (ah *AuthHandlers) GetDeviceStatus(c *fiber.Ctx) error {
 	}
 
 	// Check user devices
-	count, deviceIDs, err := ah.CheckUserDevices(userID)
+	count, deviceIDs, err := ah.CheckUserDevices(userIDStr)
 	if err != nil {
-		logrus.WithError(err).WithField("userID", userID).Error("Failed to check user devices")
+		logrus.WithError(err).WithField("userID", userIDStr).Error("Failed to check user devices")
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"success": false,
 			"error":   "Internal server error",

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -340,13 +340,13 @@ func (h *Handlers) errorResponse(c *fiber.Ctx, statusCode int, message string) e
 // GetFlows returns flows filtered by authenticated user's devices
 func (h *Handlers) GetFlows(c *fiber.Ctx) error {
 	// Get user ID from authentication context (integer version set by AuthMiddleware)
-	userID, ok := c.Locals("userID").(int)
+	userID, ok := c.Locals("user_id").(string)
 	if !ok {
 		return h.errorResponse(c, 401, "Authentication required")
 	}
 
 	// Get flows filtered by user's devices
-	flows, err := h.flowService.GetFlowsByUserDevices(userID)
+	flows, err := h.flowService.GetFlowsByUserDevices(convertUUIDToInt(userID))
 	if err != nil {
 		logrus.WithError(err).Error("Failed to get flows for user devices")
 		return h.errorResponse(c, 500, "Failed to retrieve flows")

--- a/internal/handlers/handlers_extended.go
+++ b/internal/handlers/handlers_extended.go
@@ -209,7 +209,7 @@ func (h *Handlers) GetSupportedModels(c *fiber.Ctx) error {
 // GetAnalyticsOverview returns analytics overview
 func (h *Handlers) GetAnalyticsOverview(c *fiber.Ctx) error {
 	// Get user ID from authentication context (integer version set by AuthMiddleware)
-	userID, ok := c.Locals("userID").(int)
+	userID, ok := c.Locals("user_id").(string)
 	if !ok {
 		return h.errorResponse(c, 401, "Authentication required")
 	}
@@ -224,7 +224,7 @@ func (h *Handlers) GetAnalyticsOverview(c *fiber.Ctx) error {
 	}
 
 	// Get actual flow count filtered by user's devices
-	flows, err := h.flowService.GetFlowsByUserDevices(userID)
+	flows, err := h.flowService.GetFlowsByUserDevices(convertUUIDToInt(userID))
 	if err == nil {
 		overview["total_flows"] = len(flows)
 	}
@@ -240,13 +240,13 @@ func (h *Handlers) GetFlowStats(c *fiber.Ctx) error {
 	}
 
 	// Get userID from context (integer version set by AuthMiddleware)
-	userID, ok := c.Locals("userID").(int)
+	userID, ok := c.Locals("user_id").(string)
 	if !ok {
 		return h.errorResponse(c, 401, "Authentication required")
 	}
 
 	// Verify that the flow belongs to user's devices
-	userFlows, err := h.flowService.GetFlowsByUserDevices(userID)
+	userFlows, err := h.flowService.GetFlowsByUserDevices(convertUUIDToInt(userID))
 	if err != nil {
 		logrus.WithError(err).Error("Failed to get user flows")
 		return h.errorResponse(c, 500, "Failed to verify flow ownership")
@@ -266,7 +266,7 @@ func (h *Handlers) GetFlowStats(c *fiber.Ctx) error {
 	}
 
 	// Get executions for the flow using AI WhatsApp repository
-	executions, _, err := h.aiWhatsappHandlers.AIRepo.GetAllAIWhatsappData(100, 0, "", "", flowReference, userID)
+	executions, _, err := h.aiWhatsappHandlers.AIRepo.GetAllAIWhatsappData(100, 0, "", "", flowReference, convertUUIDToInt(userID))
 	if err != nil {
 		logrus.WithError(err).Error("Failed to get flow executions")
 		return h.errorResponse(c, 500, "Failed to get flow statistics")

--- a/internal/handlers/stage_values_handlers.go
+++ b/internal/handlers/stage_values_handlers.go
@@ -21,8 +21,8 @@ type StageSetValue struct {
 // GetAllStageValues gets all stage values for authenticated user's devices
 func (h *Handlers) GetAllStageValues(c *fiber.Ctx) error {
 	// Get user ID from auth context
-	userID := c.Locals("userID")
-	if userID == nil {
+	userIDStr := c.Locals("user_id")
+	if userIDStr == nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
 			"error": "User not authenticated",
 		})
@@ -40,7 +40,7 @@ func (h *Handlers) GetAllStageValues(c *fiber.Ctx) error {
 	deviceQuery := `
 		SELECT id_device FROM device_setting_nodepath WHERE user_id = ?
 	`
-	deviceRows, err := h.db.Query(deviceQuery, userID)
+	deviceRows, err := h.db.Query(deviceQuery, userIDStr)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to fetch user devices")
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
@@ -118,8 +118,8 @@ func (h *Handlers) GetAllStageValues(c *fiber.Ctx) error {
 // CreateStageValue creates a new stage value configuration
 func (h *Handlers) CreateStageValue(c *fiber.Ctx) error {
 	// Get user ID from auth context
-	userID := c.Locals("userID")
-	if userID == nil {
+	userIDStr := c.Locals("user_id")
+	if userIDStr == nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
 			"error": "User not authenticated",
 		})
@@ -148,7 +148,7 @@ func (h *Handlers) CreateStageValue(c *fiber.Ctx) error {
 	// If no device ID provided, get first device for user
 	if req.IDDevice == "" {
 		var firstDevice string
-		err := h.db.QueryRow("SELECT id_device FROM device_setting_nodepath WHERE user_id = ? LIMIT 1", userID).Scan(&firstDevice)
+		err := h.db.QueryRow("SELECT id_device FROM device_setting_nodepath WHERE user_id = ? LIMIT 1", userIDStr).Scan(&firstDevice)
 		if err != nil {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 				"error": "No device found for user",
@@ -166,7 +166,7 @@ func (h *Handlers) CreateStageValue(c *fiber.Ctx) error {
 
 	// Verify user owns the device
 	var count int
-	err := h.db.QueryRow("SELECT COUNT(*) FROM device_setting_nodepath WHERE id_device = ? AND user_id = ?", req.IDDevice, userID).Scan(&count)
+	err := h.db.QueryRow("SELECT COUNT(*) FROM device_setting_nodepath WHERE id_device = ? AND user_id = ?", req.IDDevice, userIDStr).Scan(&count)
 	if err != nil || count == 0 {
 		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
 			"error": "You don't have permission to modify this device",
@@ -236,8 +236,8 @@ func (h *Handlers) CreateStageValue(c *fiber.Ctx) error {
 // UpdateStageValue updates an existing stage value configuration
 func (h *Handlers) UpdateStageValue(c *fiber.Ctx) error {
 	// Get user ID from auth context
-	userID := c.Locals("userID")
-	if userID == nil {
+	userIDStr := c.Locals("user_id")
+	if userIDStr == nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
 			"error": "User not authenticated",
 		})
@@ -294,7 +294,7 @@ func (h *Handlers) UpdateStageValue(c *fiber.Ctx) error {
 
 	// Verify user owns the device
 	var count int
-	err = h.db.QueryRow("SELECT COUNT(*) FROM device_setting_nodepath WHERE id_device = ? AND user_id = ?", deviceID, userID).Scan(&count)
+	err = h.db.QueryRow("SELECT COUNT(*) FROM device_setting_nodepath WHERE id_device = ? AND user_id = ?", deviceID, userIDStr).Scan(&count)
 	if err != nil || count == 0 {
 		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
 			"error": "You don't have permission to modify this stage value",
@@ -330,8 +330,8 @@ func (h *Handlers) UpdateStageValue(c *fiber.Ctx) error {
 // DeleteStageValue deletes a stage value configuration
 func (h *Handlers) DeleteStageValue(c *fiber.Ctx) error {
 	// Get user ID from auth context
-	userID := c.Locals("userID")
-	if userID == nil {
+	userIDStr := c.Locals("user_id")
+	if userIDStr == nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
 			"error": "User not authenticated",
 		})
@@ -375,7 +375,7 @@ func (h *Handlers) DeleteStageValue(c *fiber.Ctx) error {
 
 	// Verify user owns the device
 	var count int
-	err = h.db.QueryRow("SELECT COUNT(*) FROM device_setting_nodepath WHERE id_device = ? AND user_id = ?", deviceID, userID).Scan(&count)
+	err = h.db.QueryRow("SELECT COUNT(*) FROM device_setting_nodepath WHERE id_device = ? AND user_id = ?", deviceID, userIDStr).Scan(&count)
 	if err != nil || count == 0 {
 		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
 			"error": "You don't have permission to delete this stage value",

--- a/internal/handlers/wasapbot_handlers.go
+++ b/internal/handlers/wasapbot_handlers.go
@@ -23,7 +23,7 @@ func NewWasapBotHandlers(wasapBotRepo repository.WasapBotRepository) *WasapBotHa
 // GetWasapBotData retrieves WasapBot data with filters
 func (h *WasapBotHandlers) GetWasapBotData(c *fiber.Ctx) error {
 	// Get user ID from context
-	userIDInterface := c.Locals("userID")
+	userIDInterface := c.Locals("user_id")
 	if userIDInterface == nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
 			"error": "User not authenticated",
@@ -89,7 +89,7 @@ func (h *WasapBotHandlers) GetWasapBotData(c *fiber.Ctx) error {
 // GetWasapBotStats retrieves WasapBot statistics
 func (h *WasapBotHandlers) GetWasapBotStats(c *fiber.Ctx) error {
 	// Get user ID from context
-	userIDInterface := c.Locals("userID")
+	userIDInterface := c.Locals("user_id")
 	if userIDInterface == nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
 			"error": "User not authenticated",
@@ -131,7 +131,7 @@ func (h *WasapBotHandlers) GetWasapBotStats(c *fiber.Ctx) error {
 // DeleteWasapBotRecord deletes a WasapBot record
 func (h *WasapBotHandlers) DeleteWasapBotRecord(c *fiber.Ctx) error {
 	// Get user ID from context
-	userIDInterface := c.Locals("userID")
+	userIDInterface := c.Locals("user_id")
 	if userIDInterface == nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
 			"error": "User not authenticated",


### PR DESCRIPTION
## Issue
After migrating device_setting_nodepath.user_id from INT to CHAR(36), the authentication middleware was still setting both `userID` (as int) and `user_id` (as string), causing device detection to fail. The API returned `device_count: 0` and `has_devices: false` even though devices existed in the database.

## Root Cause
- AuthMiddleware was converting UUID to int and setting both `userID` and `user_id` in context
- DeviceRequiredMiddleware, GetDeviceStatus, and CheckUserDevices were still using int userID
- Other handlers (ai_whatsapp, wasapbot, stage_values) were still using the old `c.Locals("userID").(int)` pattern
- Database queries with int user_id couldn't match CHAR(36) UUID values

## Changes
1. **AuthMiddleware** - Now sets only `user_id` as string UUID, removed int conversion
2. **DeviceRequiredMiddleware** - Updated to use `c.Locals("user_id").(string)`
3. **CheckUserDevices** - Changed parameter from `int` to `string`
4. **GetDeviceStatus** - Updated to use string user_id
5. **All Handlers** - Replaced `c.Locals("userID").(int)` with `c.Locals("user_id").(string)`
   - ai_whatsapp_handlers.go
   - handlers.go
   - handlers_extended.go  
   - stage_values_handlers.go
   - wasapbot_handlers.go
6. **Legacy Compatibility** - Added `convertUUIDToInt()` calls for repository methods that still expect int

## Testing
- ✅ Build successful with `CGO_ENABLED=0`
- ✅ All compilation errors resolved
- ✅ Device detection now works correctly with UUID user_id values

## Impact
This fix resolves the sidebar navigation device error and allows users to properly access features that require device ownership verification.

---

**Related to PR #26** - This is a follow-up fix for the user_id migration
**Droid-assisted PR**